### PR TITLE
fix #2 empty .launcher.conf

### DIFF
--- a/start.ipynb
+++ b/start.ipynb
@@ -20,7 +20,8 @@
     "from pprint import pformat\n",
     "from markdown import markdown\n",
     "from importlib import import_module\n",
-    "from IPython.display import clear_output, Markdown"
+    "from IPython.display import clear_output, Markdown\n",
+    "import json"
    ]
   },
   {
@@ -187,10 +188,12 @@
    "source": [
     "def record_showhide(name, visible):\n",
     "    config = read_config()\n",
+    "    hidden = set(config['hidden'])\n",
     "    if visible:\n",
-    "        config['hidden'].discard(name)\n",
+    "        hidden.discard(name)\n",
     "    else:\n",
-    "        config['hidden'].add(name)\n",
+    "        hidden.add(name)\n",
+    "    config['hidden'] = list(hidden)\n",
     "    write_config(config)"
    ]
   },
@@ -200,16 +203,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "CONFIG_FN = \".launcher.conf\"\n",
+    "CONFIG_FN = \".launcher.json\"\n",
     "def read_config():\n",
     "    if path.exists(CONFIG_FN):\n",
-    "        return eval(open(CONFIG_FN).read())\n",
+    "        return json.load(open(CONFIG_FN,'r'))\n",
     "    else:\n",
-    "        return {'order':[], 'hidden':set()} #default config\n",
+    "        return {'order':[], 'hidden':[]} #default config\n",
     "\n",
     "def write_config(config):\n",
-    "    with open(CONFIG_FN, \"w\") as f:\n",
-    "        f.write(pformat(config))"
+    "    json.dump(config, open(CONFIG_FN,'w'), indent=2)"
    ]
   },
   {


### PR DESCRIPTION
Fix #2 

This changes to a json format for the config file,
which eliminates the dirty `eval` statement.

Since json can not represent sets, 2 lines of code are added
for hide/show (code is removed in other places).
I think this is a fair tradeoff.