### PR TITLE
disable output scrolling

### DIFF
--- a/start.ipynb
+++ b/start.ipynb
@@ -1,6 +1,18 @@
 {
  "cells": [
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%javascript\n",
+    "IPython.OutputArea.prototype._should_scroll = function(lines) {\n",
+    "    return false;\n",
+    "}"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [


### PR DESCRIPTION
When ipywidget.Output() objects grow beyond some height they will be automatically collapsed and a scrollbar added. With the added javascript line this behavior is suppressed.

Unfortunately there is no nicer way of achieving this. (see https://github.com/jupyter-widgets/ipywidgets/issues/1791)